### PR TITLE
Ubuntu notes, reversed link order.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: akemi
 	$(CC) $(CFLAGS) -o $@ $<
 
 akemi: $(OBJ)
-	$(LD) $(LIBS) $(OBJ) -o $@
+	$(LD) $(OBJ) $(LIBS) -o $@
 
 install: akemi
 	cp akemi /usr/bin/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Build:
 After installing the relevant developement packages for fuse and xcb for your distro, akemi can be built using the make command.
 Installation can be done by invoking make install.
 
+### Ubuntu 14.04 dependencies
+
+    sudo apt-get install libxcb1-dev libfuse-dev
+
 Usage:
 ---
 See the wiki (http://github.com/QBCO/akemi/wiki) for more information.


### PR DESCRIPTION
Objects should come before libraries.  Eg: http://stackoverflow.com/questions/45135/linker-order-gcc